### PR TITLE
Added some buffer checks

### DIFF
--- a/GOffsets/GOffsets.cpp
+++ b/GOffsets/GOffsets.cpp
@@ -16,10 +16,19 @@ std::vector<Byte> readBinaryFile(const std::string& filename) {
         return {};
     }
     file.seekg(0, std::ios::end);
-    size_t fileSize = file.tellg();
+    std::streampos fileSizePos = file.tellg();
+    if (fileSizePos == std::streampos(-1)) {
+        std::cerr << "Error: Failed to determine size of " << filename << std::endl;
+        return {};
+    }
+    size_t fileSize = static_cast<size_t>(fileSizePos);
     std::vector<Byte> buffer(fileSize);
     file.seekg(0, std::ios::beg);
     file.read(reinterpret_cast<char*>(buffer.data()), fileSize);
+    if (!file || static_cast<size_t>(file.gcount()) != fileSize) {
+        std::cerr << "Error: Failed to read file " << filename << std::endl;
+        return {};
+    }
     return buffer;
 }
 

--- a/GOffsets/GOffsets.cpp
+++ b/GOffsets/GOffsets.cpp
@@ -176,6 +176,8 @@ size_t findPatternMask(const std::vector<Byte>& data,
     const std::string& mask) {
     if (pattern.size() != mask.size() || pattern.empty() || data.empty())
         return std::string::npos;
+    if (data.size() < pattern.size())
+        return std::string::npos;
     for (size_t i = 0; i <= data.size() - pattern.size(); ++i) {
         bool found = true;
         for (size_t j = 0; j < pattern.size(); ++j) {

--- a/GOffsets/GOffsets.cpp
+++ b/GOffsets/GOffsets.cpp
@@ -240,11 +240,14 @@ uint64_t findOffsetInProcessMemory(HANDLE hProcess, const std::vector<Byte>& pat
     if (!GetModuleInformation(hProcess, hMod, &modInfo, sizeof(modInfo)))
         return 0;
     std::vector<Byte> buffer(modInfo.SizeOfImage);
-    SIZE_T bytesRead;
+    SIZE_T bytesRead = 0;
     if (!ReadProcessMemory(hProcess, modInfo.lpBaseOfDll, buffer.data(), modInfo.SizeOfImage, &bytesRead))
         return 0;
+
+    buffer.resize(bytesRead);
+
     size_t foundOffset = findPatternMask(buffer, pattern, mask);
-    if (foundOffset == std::string::npos || foundOffset + 7 > buffer.size())
+    if (foundOffset == std::string::npos || foundOffset + 7 > bytesRead)
         return 0;
     foundOffset = adjustFoundOffsetForGroup(buffer, foundOffset, group);
     int32_t disp = *reinterpret_cast<const int32_t*>(&buffer[foundOffset + 3]);

--- a/UEVersionScanner/UEVersionScanner.cpp
+++ b/UEVersionScanner/UEVersionScanner.cpp
@@ -27,6 +27,11 @@ static bool FileExists(const std::string& filePath) {
     return (attrib != INVALID_FILE_ATTRIBUTES && !(attrib & FILE_ATTRIBUTE_DIRECTORY));
 }
 
+// Helper: ensures the buffer we want to scan is large enough for the marker.
+static bool CanScan(size_t bufferSize, size_t markerLen) {
+    return bufferSize >= markerLen;
+}
+
 std::string GetVersionFromResource(const std::string& filePath) {
     char modulePath[MAX_PATH] = { 0 };
     strcpy_s(modulePath, filePath.c_str());
@@ -97,6 +102,8 @@ std::string GetVersionFromMemoryScan() {
     std::vector<std::string> markers = { "Unreal Engine 4.", "Unreal Engine 5.", "FEngineVersion", "EngineVersion" };
     for (const auto& marker : markers) {
         size_t markerLen = marker.length();
+        if (!CanScan(moduleSize, markerLen))
+            continue;
         for (size_t i = 0; i < moduleSize - markerLen; i++) {
             if (memcmp(baseAddr + i, marker.c_str(), markerLen) == 0) {
                 std::string found(marker);
@@ -125,6 +132,8 @@ std::string GetVersionFromProcessMemory(HANDLE hProcess) {
                 std::vector<std::string> markers = { "Unreal Engine 4.", "Unreal Engine 5.", "FEngineVersion", "EngineVersion" };
                 for (const auto& marker : markers) {
                     size_t markerLen = marker.length();
+                    if (!CanScan(buffer.size(), markerLen))
+                        continue;
                     for (size_t i = 0; i < buffer.size() - markerLen; i++) {
                         if (memcmp(buffer.data() + i, marker.c_str(), markerLen) == 0) {
                             std::string found(marker);


### PR DESCRIPTION
### findPatternMask subtracts pattern.size() from data.size() without first ensuring the data buffer is large enough, which can underflow and lead to invalid memory reads when pattern.size() > data.size()  

### readBinaryFile uses file.tellg() to size a buffer but never validates the result or confirms the read succeeded, risking huge allocations or truncated data that could later cause invalid access  

### Both GetVersionFromMemoryScan and GetVersionFromProcessMemory compute loop bounds with moduleSize - markerLen (or buffer.size() - markerLen), which can underflow if the module is smaller than the marker, leading to runaway loops and invalid reads  

### After ReadProcessMemory, subsequent searches iterate over buffer.size() rather than the actual number of bytes read (bytesRead), causing scans through uninitialized memory and possible false matches  